### PR TITLE
Fix initializer call and URL helper

### DIFF
--- a/AD/AD/Classes/Controller/TabFirstViewController.swift
+++ b/AD/AD/Classes/Controller/TabFirstViewController.swift
@@ -12,6 +12,7 @@ import Kingfisher
 class TabFirstViewController: UITableViewController {
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
     }
     

--- a/AD/AD/Classes/OriginData/Data.swift
+++ b/AD/AD/Classes/OriginData/Data.swift
@@ -38,7 +38,7 @@ extension URL{
         let allowedCharacterSet = CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[] ").inverted
         if let escapedString = string.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) {
            print(escapedString)
-            let url = URL.init(string: escapedString ?? "")
+            let url = URL(string: escapedString)
             return url
         }
         


### PR DESCRIPTION
## Summary
- ensure TabFirstViewController calls `super.viewDidLoad()`
- drop unused fallback string in URL initializer

## Testing
- `swiftc -parse AD/AD/Classes/Controller/TabFirstViewController.swift AD/AD/Classes/Model/ADModel.swift AD/AD/Classes/OriginData/Data.swift`

------
https://chatgpt.com/codex/tasks/task_e_6878834ec7ec8320954c766e093ef353